### PR TITLE
Add thread-safe console and file logger

### DIFF
--- a/Core/NE.Standard/Logging/ConsoleLogger.cs
+++ b/Core/NE.Standard/Logging/ConsoleLogger.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace NE.Standard.Logging
+{
+    /// <summary>
+    /// Thread-safe console logger with color support.
+    /// </summary>
+    public class ConsoleLogger<T> : NeLogger<T>
+    {
+        private static readonly object _lock = new();
+
+        protected override void WriteFormatted(LogLevel level, string message)
+        {
+            var output = FormatMessage(level, message);
+            lock (_lock)
+            {
+                var color = Console.ForegroundColor;
+                Console.ForegroundColor = GetColor(level);
+                Console.WriteLine(output);
+                Console.ForegroundColor = color;
+            }
+        }
+
+        private static ConsoleColor GetColor(LogLevel level) => level switch
+        {
+            LogLevel.Debug => ConsoleColor.Gray,
+            LogLevel.Information => ConsoleColor.Green,
+            LogLevel.Warning => ConsoleColor.Yellow,
+            LogLevel.Error => ConsoleColor.Red,
+            _ => Console.ForegroundColor
+        };
+    }
+}

--- a/Core/NE.Standard/Logging/FileLogger.cs
+++ b/Core/NE.Standard/Logging/FileLogger.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace NE.Standard.Logging
+{
+    /// <summary>
+    /// Thread-safe file logger that cleans old log files.
+    /// </summary>
+    public class FileLogger<T> : NeLogger<T>
+    {
+        private readonly string _directory;
+        private readonly int _retentionDays;
+        private readonly object _lock = new();
+        private DateTime _lastCleanup = DateTime.MinValue;
+
+        public FileLogger(string directory, int retentionDays = 7)
+        {
+            _directory = directory;
+            _retentionDays = retentionDays;
+            Directory.CreateDirectory(_directory);
+        }
+
+        protected override void WriteFormatted(LogLevel level, string message)
+        {
+            var output = FormatMessage(level, message);
+            var file = Path.Combine(_directory, $"{DateTime.Now:yyyy-MM-dd}.log");
+            lock (_lock)
+            {
+                File.AppendAllText(file, output + Environment.NewLine);
+                CleanupIfNeeded();
+            }
+        }
+
+        private void CleanupIfNeeded()
+        {
+            if ((DateTime.Now - _lastCleanup).TotalHours < 1) return;
+            _lastCleanup = DateTime.Now;
+            try
+            {
+                var threshold = DateTime.Now.AddDays(-_retentionDays);
+                var files = Directory.GetFiles(_directory, "*.log")
+                    .Select(f => new FileInfo(f));
+                foreach (var f in files)
+                    if (f.CreationTime < threshold)
+                        f.Delete();
+            }
+            catch
+            {
+                // ignore cleanup errors
+            }
+        }
+    }
+}

--- a/Core/NE.Standard/Logging/INeLogger.cs
+++ b/Core/NE.Standard/Logging/INeLogger.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace NE.Standard.Logging
+{
+    /// <summary>
+    /// Common logger interface with a category.
+    /// </summary>
+    public interface INeLogger<out T>
+    {
+        void Log(LogLevel level, string message);
+
+        void Debug(string message) => Log(LogLevel.Debug, message);
+        void Information(string message) => Log(LogLevel.Information, message);
+        void Warning(string message) => Log(LogLevel.Warning, message);
+        void Error(string message, Exception? exception = null);
+    }
+}

--- a/Core/NE.Standard/Logging/LogLevel.cs
+++ b/Core/NE.Standard/Logging/LogLevel.cs
@@ -1,0 +1,13 @@
+namespace NE.Standard.Logging
+{
+    /// <summary>
+    /// Defines severity levels for logging.
+    /// </summary>
+    public enum LogLevel
+    {
+        Debug,
+        Information,
+        Warning,
+        Error
+    }
+}

--- a/Core/NE.Standard/Logging/NeLogger.cs
+++ b/Core/NE.Standard/Logging/NeLogger.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace NE.Standard.Logging
+{
+    /// <summary>
+    /// Base implementation for <see cref="INeLogger{T}"/>.
+    /// </summary>
+    public abstract class NeLogger<T> : INeLogger<T>
+    {
+        protected string Category { get; } = typeof(T).Name;
+
+        public virtual void Log(LogLevel level, string message)
+        {
+            WriteFormatted(level, message);
+        }
+
+        public virtual void Error(string message, Exception? exception = null)
+        {
+            var fullMessage = exception == null
+                ? message
+                : message + " | " + exception;
+            WriteFormatted(LogLevel.Error, fullMessage);
+        }
+
+        protected string FormatMessage(LogLevel level, string message)
+        {
+            return $"[{DateTime.Now:MM.dd.yyyy HH:mm:ss.fff}][{level}][{Category}]: {message}";
+        }
+
+        protected abstract void WriteFormatted(LogLevel level, string message);
+    }
+}

--- a/Core/NE.Standard/Logging/NeLoggingServiceCollectionExtensions.cs
+++ b/Core/NE.Standard/Logging/NeLoggingServiceCollectionExtensions.cs
@@ -1,0 +1,25 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace NE.Standard.Logging
+{
+    /// <summary>
+    /// Service collection extensions for NE logger.
+    /// </summary>
+    public static class NeLoggingServiceCollectionExtensions
+    {
+        public static IServiceCollection AddConsoleNeLogger<T>(this IServiceCollection services)
+            where T : class
+        {
+            services.AddSingleton<INeLogger<T>, ConsoleLogger<T>>();
+            return services;
+        }
+
+        public static IServiceCollection AddFileNeLogger<T>(this IServiceCollection services, string directory, int retentionDays = 7)
+            where T : class
+        {
+            services.AddSingleton<INeLogger<T>>(sp => new FileLogger<T>(directory, retentionDays));
+            return services;
+        }
+    }
+}

--- a/Core/NE.Standard/NE.Standard.csproj
+++ b/Core/NE.Standard/NE.Standard.csproj
@@ -5,4 +5,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- add generic NE logger interface with severity levels
- implement thread-safe console logger with colors
- implement thread-safe file logger that cleans up old files
- provide DI registration helpers
- reference `Microsoft.Extensions.DependencyInjection.Abstractions`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6862a42369e883309794ec52bed04e35