### PR TITLE
Improve CompactSerializer and add tests

### DIFF
--- a/Core/NE.Standard/Extensions/StringExtensions.cs
+++ b/Core/NE.Standard/Extensions/StringExtensions.cs
@@ -153,6 +153,18 @@ namespace NE.Standard.Extensions
             return TimeSpan.TryParseExact(value, format ?? GeneralConstants.TIMESPAN_FORMAT, provider ?? CultureInfo.InvariantCulture, out var exact) ? exact : (TimeSpan?)null;
         }
 
+        /// <summary>
+        /// Converts the string to the specified enumeration value.
+        /// </summary>
+        public static object ToEnum(this string value, Type enumType)
+            => Enum.Parse(enumType ?? throw new ArgumentNullException(nameof(enumType)), value);
+
+        /// <summary>
+        /// Converts the string to the specified enumeration value.
+        /// </summary>
+        public static T ToEnum<T>(this string value) where T : struct, Enum
+            => (T)Enum.Parse(typeof(T), value);
+
         #endregion
 
         #region String operations

--- a/Core/NE.Standard/Serialization/CompactSerializer.Deserialize.cs
+++ b/Core/NE.Standard/Serialization/CompactSerializer.Deserialize.cs
@@ -50,9 +50,9 @@ namespace NE.Standard.Serialization
             if (targetType == typeof(float)) return data.ToFloat();
             if (targetType == typeof(double)) return data.ToDouble();
             if (targetType == typeof(decimal)) return data.ToDecimal();
-            if (targetType.IsEnum) return Enum.Parse(targetType, data);
+            if (targetType.IsEnum) return data.ToEnum(targetType);
 
-            var instance = Activator.CreateInstance(targetType);
+            var instance = targetType.CreateInstance();
             if (instance == null) return null;
 
             if (targetType.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>)))
@@ -79,7 +79,7 @@ namespace NE.Standard.Serialization
                     return enumerableType.GetMethod(nameof(Enumerable.ToArray))?.MakeGenericMethod(itemType!)
                         .Invoke(null, new object[] { casted });
                 if (targetType.IsGenericType && targetType.GetGenericTypeDefinition() == typeof(ObservableCollection<>))
-                    return Activator.CreateInstance(targetType, casted);
+                    return targetType.CreateInstance(new object[] { casted });
                 return enumerableType.GetMethod(nameof(Enumerable.ToList))?.MakeGenericMethod(itemType!)
                     .Invoke(null, new object[] { casted });
             }

--- a/Core/NE.Standard/Serialization/CompactSerializer.Serialize.cs
+++ b/Core/NE.Standard/Serialization/CompactSerializer.Serialize.cs
@@ -45,6 +45,14 @@ namespace NE.Standard.Serialization
                     _builder.Append(">");
                 }
             }
+            else if (type == typeof(DateTime))
+            {
+                _builder.Append($"({GetOrAddTypeId(type)}){((DateTime)obj).ToFormat()}");
+            }
+            else if (type == typeof(TimeSpan))
+            {
+                _builder.Append($"({GetOrAddTypeId(type)}){((TimeSpan)obj).ToFormat()}");
+            }
             else
             {
                 _builder.Append($"({GetOrAddTypeId(type)}){obj}");

--- a/Tests/NE.Tests.Standard/CompactSerializerTests.cs
+++ b/Tests/NE.Tests.Standard/CompactSerializerTests.cs
@@ -1,0 +1,27 @@
+using NE.Standard.Extensions;
+using NE.Standard.Serialization;
+
+namespace NE.Tests.Standard;
+
+public class CompactSerializerTests
+{
+    [Fact]
+    public void SerializeDeserialize_DateTimeAndTimeSpan()
+    {
+        var serializer = new CompactSerializer();
+        var date = new DateTime(2024, 1, 2, 3, 4, 5, 200);
+        var time = new TimeSpan(1, 2, 3);
+
+        string dateData = serializer.Serialize(date, useBase64: false);
+        string timeData = serializer.Serialize(time, useBase64: false);
+
+        Assert.Contains(date.ToFormat(), dateData);
+        Assert.Contains(time.ToFormat(), timeData);
+
+        var roundDate = serializer.Deserialize<DateTime>(dateData, useBase64: false);
+        var roundTime = serializer.Deserialize<TimeSpan>(timeData, useBase64: false);
+
+        Assert.Equal(date, roundDate);
+        Assert.Equal(time, roundTime);
+    }
+}

--- a/Tests/NE.Tests.Standard/StringExtensionsTests.cs
+++ b/Tests/NE.Tests.Standard/StringExtensionsTests.cs
@@ -2,6 +2,8 @@ using NE.Standard.Extensions;
 
 namespace NE.Tests.Standard;
 
+enum ParseEnum { Alpha, Beta }
+
 public class StringExtensionsTests
 {
     [Fact]
@@ -56,6 +58,9 @@ public class StringExtensionsTests
         var time = timeStr.ToTime();
         Assert.Equal(new TimeSpan(1, 2, 3), time);
         Assert.Null("bad".ToNullableTime());
+
+        Assert.Equal(ParseEnum.Beta, "Beta".ToEnum<ParseEnum>());
+        Assert.Equal(ParseEnum.Alpha, "Alpha".ToEnum(typeof(ParseEnum)));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add enum conversion helpers
- serialize DateTime and TimeSpan using constant formats
- use TypeExtensions.CreateInstance when deserializing
- add CompactSerializer tests and extend StringExtensions tests