### PR TITLE
Improve serializer naming and attribute checks

### DIFF
--- a/Core/NE.Standard/Extensions/TypeExtensions.cs
+++ b/Core/NE.Standard/Extensions/TypeExtensions.cs
@@ -92,5 +92,16 @@ namespace NE.Standard.Extensions
 
             return true;
         }
+
+        /// <summary>
+        /// Determines whether the member has the specified attribute applied.
+        /// </summary>
+        public static bool HasAttribute<TAttribute>(this MemberInfo member, bool inherit = false) where TAttribute : Attribute
+        {
+            if (member == null)
+                throw new ArgumentNullException(nameof(member));
+
+            return Attribute.IsDefined(member, typeof(TAttribute), inherit);
+        }
     }
 }

--- a/Core/NE.Standard/Serialization/NeSerializer.Deserialize.cs
+++ b/Core/NE.Standard/Serialization/NeSerializer.Deserialize.cs
@@ -8,7 +8,7 @@ using System.Reflection;
 
 namespace NE.Standard.Serialization
 {
-    public partial class NESerializer
+    public partial class NeSerializer
     {
         public object? Deserialize(string data, bool useBase64 = true)
         {
@@ -111,7 +111,7 @@ namespace NE.Standard.Serialization
 
             var type = obj.GetType();
 
-            if (type.GetCustomAttribute<NESerializableAttribute>() != null)
+            if (type.HasAttribute<NESerializableAttribute>())
             {
                 foreach (var param in ExtractSegments(data))
                 {

--- a/Core/NE.Standard/Serialization/NeSerializer.Serialize.cs
+++ b/Core/NE.Standard/Serialization/NeSerializer.Serialize.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace NE.Standard.Serialization
 {
-    public partial class NESerializer
+    public partial class NeSerializer
     {
         private string SerializeInternal(object obj, bool useBase64 = true, bool ignoreReference = false)
         {
@@ -31,14 +31,14 @@ namespace NE.Standard.Serialization
             if (type == null)
                 return;
 
-            if (type.GetCustomAttribute<NESerializableAttribute>() != null)
+            if (type.HasAttribute<NESerializableAttribute>())
             {
                 if (!type.IsValueType && !TrackReference(obj))
                     return;
 
                 foreach (var prop in type.GetProperties())
                 {
-                    if (prop.SetMethod == null || prop.GetCustomAttribute<NEIgnoreAttribute>() != null)
+                    if (prop.SetMethod == null || prop.HasAttribute<NEIgnoreAttribute>())
                         continue;
 
                     var value = prop.GetValue(obj);
@@ -131,13 +131,13 @@ namespace NE.Standard.Serialization
             if (type == null)
                 return;
 
-            if (type.GetCustomAttribute<NESerializableAttribute>() != null)
+            if (type.HasAttribute<NESerializableAttribute>())
             {
                 builder.Append($"({GetOrAddTypeId(type)})");
 
                 foreach (var prop in type.GetProperties())
                 {
-                    if (prop.SetMethod == null || prop.GetCustomAttribute<NEIgnoreAttribute>() != null)
+                    if (prop.SetMethod == null || prop.HasAttribute<NEIgnoreAttribute>())
                         continue;
 
                     var value = prop.GetValue(obj);

--- a/Core/NE.Standard/Serialization/NeSerializer.cs
+++ b/Core/NE.Standard/Serialization/NeSerializer.cs
@@ -11,7 +11,7 @@ namespace NE.Standard.Serialization
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class NEIgnoreAttribute : Attribute { }
 
-    public partial class NESerializer : IDisposable
+    public partial class NeSerializer : IDisposable
     {
         private const char FIRST_ST = '~';
         private const string STRING_T = "~[";

--- a/Tests/NE.Tests.Standard/NeSerializerTests.cs
+++ b/Tests/NE.Tests.Standard/NeSerializerTests.cs
@@ -2,7 +2,7 @@ using NE.Standard.Serialization;
 
 namespace NE.Tests.Standard;
 
-public class NESerializerTests
+public class NeSerializerTests
 {
     private enum TestEnum
     {
@@ -54,7 +54,7 @@ public class NESerializerTests
     [Fact]
     public void SerializeDeserialize_DateTimeAndTimeSpan()
     {
-        var serializer = new NESerializer();
+        var serializer = new NeSerializer();
 
         var obj = new TestSerializer
         {
@@ -92,50 +92,38 @@ public class NESerializerTests
         var data = serializer.Serialize(obj);
         var obj2 = serializer.Deserialize<TestSerializer>(data);
 
-        if (obj2.V == false)
-            Assert.Fail();
+        Assert.True(obj2.V);
 
-        if (obj2.V1 != 1)
-            Assert.Fail();
+        Assert.Equal(1, obj2.V1);
 
-        if (obj2.V1Ignore == 1)
-            Assert.Fail();
+        Assert.NotEqual(1, obj2.V1Ignore);
 
-        if (obj2.V2 != 2.2f)
-            Assert.Fail();
+        Assert.Equal(2.2f, obj2.V2);
 
-        if (obj2.V3 != 3.3)
-            Assert.Fail();
+        Assert.Equal(3.3, obj2.V3);
 
-        if (obj2.Text != "~[Test&^$(']")
-            Assert.Fail();
+        Assert.Equal("~[Test&^$(']", obj2.Text);
 
-        if (obj2.Date != new DateTime(2000, 1, 1))
-            Assert.Fail();
+        Assert.Equal(new DateTime(2000, 1, 1), obj2.Date);
 
-        if (obj2.Time != new TimeSpan(1, 2, 3, 4, 5) - new TimeSpan(2, 3, 4, 5, 6))
-            Assert.Fail();
+        Assert.Equal(new TimeSpan(1, 2, 3, 4, 5) - new TimeSpan(2, 3, 4, 5, 6), obj2.Time);
 
-        if (obj2.DateNull != null)
-            Assert.Fail();
+        Assert.Null(obj2.DateNull);
 
-        if (obj2.Enum != TestEnum.V3)
-            Assert.Fail();
+        Assert.Equal(TestEnum.V3, obj2.Enum);
 
-        if (obj2.Ints?[0] != 1 || obj2.Ints[1] != 2)
-            Assert.Fail();
+        Assert.Equal(new[] {1, 2}, obj2.Ints);
 
-        if (obj2.Floats?[0] != 2.2f || obj2.Floats[1] != 3.3f)
-            Assert.Fail();
+        Assert.Equal(new List<float>{2.2f,3.3f}, obj2.Floats);
 
-        if (obj2.TestInterface == null || obj2.TestInterface.Text != "~[Test&^$(']")
-            Assert.Fail();
+        Assert.NotNull(obj2.TestInterface);
+        Assert.Equal("~[Test&^$(']", obj2.TestInterface?.Text);
 
-        if (obj2.SubTestClass == null || obj2.SubTestClass.Text != "~[Test&^$(']")
-            Assert.Fail();
+        Assert.NotNull(obj2.SubTestClass);
+        Assert.Equal("~[Test&^$(']", obj2.SubTestClass?.Text);
 
-        if (obj2.SubTestStruct == null || obj2.SubTestStruct?.Text != "~[Test&^$(']")
-            Assert.Fail();
+        Assert.NotNull(obj2.SubTestStruct);
+        Assert.Equal("~[Test&^$(']", obj2.SubTestStruct?.Text);
     }
 
     [NESerializable]
@@ -164,7 +152,7 @@ public class NESerializerTests
     [Fact]
     public void TestReference1()
     {
-        var serializer = new NESerializer();
+        var serializer = new NeSerializer();
 
         var r1 = new ReferenceTest
         {
@@ -183,14 +171,13 @@ public class NESerializerTests
 
         res.SubData1.Data = "0";
 
-        if (res.Data != "0")
-            Assert.Fail();
+        Assert.Equal("0", res.Data);
     }
 
     [Fact]
     public void TestReference2()
     {
-        var serializer = new NESerializer();
+        var serializer = new NeSerializer();
 
         var r1 = new ReferenceTest
         {
@@ -209,14 +196,13 @@ public class NESerializerTests
 
         res.SubData2.Data = "0";
 
-        if (res.SubData1.Data != "0")
-            Assert.Fail();
+        Assert.Equal("0", res.SubData1.Data);
     }
 
     [Fact]
     public void TestReference3()
     {
-        var serializer = new NESerializer();
+        var serializer = new NeSerializer();
 
         var r1 = new ReferenceTest
         {
@@ -235,14 +221,13 @@ public class NESerializerTests
 
         res.SubData2.Data = "0";
 
-        if (res.SubData1.Data == "0")
-            Assert.Fail();
+        Assert.NotEqual("0", res.SubData1.Data);
     }
 
     [Fact]
     public void TestReference4()
     {
-        var serializer = new NESerializer();
+        var serializer = new NeSerializer();
 
         var r = new ReferenceTestArray
         {
@@ -272,10 +257,7 @@ public class NESerializerTests
         res.Data = "0";
         res.Items["1"].Data = "0";
 
-        if (res.Items["1"].Parent.Data != "0")
-            Assert.Fail();
-
-        if (res.Items["3"].Data != "0")
-            Assert.Fail();
+        Assert.Equal("0", res.Items["1"].Parent.Data);
+        Assert.Equal("0", res.Items["3"].Data);
     }
 }


### PR DESCRIPTION
## Summary
- rename `NESerializer` to `NeSerializer`
- introduce `HasAttribute` extension for simple attribute checks
- update serialization code to use new helper
- modernize `NeSerializerTests` using xUnit assertions