### PR TITLE
Add property/field reflection utilities

### DIFF
--- a/Core/NE.Standard/Extensions/RefletionExtensions.cs
+++ b/Core/NE.Standard/Extensions/RefletionExtensions.cs
@@ -89,5 +89,60 @@ namespace NE.Standard.Extensions
 
             field.SetValue(obj, value);
         }
+
+        /// <summary>
+        /// Returns all properties of the given type.
+        /// </summary>
+        public static IEnumerable<PropertyInfo> GetProperties(this Type type, bool requireSetter = false)
+        {
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
+            var props = type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            return requireSetter ? props.Where(p => p.SetMethod != null) : props;
+        }
+
+        /// <summary>
+        /// Returns all properties of the given type which are marked with the specified attribute.
+        /// </summary>
+        public static IEnumerable<PropertyInfo> GetProperties<TAttribute>(this Type type, bool requireSetter = false) where TAttribute : Attribute
+        {
+            return type.GetProperties(requireSetter).Where(p => p.HasAttribute<TAttribute>());
+        }
+
+        /// <summary>
+        /// Returns all fields of the given type.
+        /// </summary>
+        public static IEnumerable<FieldInfo> GetFields(this Type type)
+        {
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
+            return type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        }
+
+        /// <summary>
+        /// Returns all fields of the given type which are marked with the specified attribute.
+        /// </summary>
+        public static IEnumerable<FieldInfo> GetFields<TAttribute>(this Type type) where TAttribute : Attribute
+        {
+            return type.GetFields().Where(f => f.HasAttribute<TAttribute>());
+        }
+
+        /// <summary>
+        /// Retrieves an attribute applied to the property.
+        /// </summary>
+        public static TAttribute GetAttribute<TAttribute>(this PropertyInfo property) where TAttribute : Attribute
+        {
+            if (property == null) throw new ArgumentNullException(nameof(property));
+            return property.GetCustomAttribute<TAttribute>()!;
+        }
+
+        /// <summary>
+        /// Retrieves an attribute applied to the field.
+        /// </summary>
+        public static TAttribute GetAttribute<TAttribute>(this FieldInfo field) where TAttribute : Attribute
+        {
+            if (field == null) throw new ArgumentNullException(nameof(field));
+            return field.GetCustomAttribute<TAttribute>()!;
+        }
     }
 }

--- a/Tests/NE.Tests.Standard/RefletionExtensionsTests.cs
+++ b/Tests/NE.Tests.Standard/RefletionExtensionsTests.cs
@@ -11,6 +11,8 @@ public class RefletionExtensionsTests
         public int Field;
         public string Property { get; set; } = string.Empty;
         [Description("sample attr")] public int Annotated { get; set; }
+        public int ReadOnly { get; } = 1;
+        [Description("field attr")] public int AnnotatedField;
     }
 
     [Fact]
@@ -43,5 +45,43 @@ public class RefletionExtensionsTests
         var s = new Sample();
         s.SetFieldValue("Field", 5);
         Assert.Equal(5, s.Field);
+    }
+
+    [Fact]
+    public void GetProperties_ReturnsFiltered()
+    {
+        var all = typeof(Sample).GetProperties().Select(p => p.Name);
+        Assert.Contains("Property", all);
+        Assert.Contains("Annotated", all);
+        Assert.Contains("ReadOnly", all);
+
+        var withSet = typeof(Sample).GetProperties(true).Select(p => p.Name);
+        Assert.DoesNotContain("ReadOnly", withSet);
+
+        var annotated = typeof(Sample).GetProperties<DescriptionAttribute>().ToList();
+        Assert.Single(annotated);
+        Assert.Equal("Annotated", annotated[0].Name);
+    }
+
+    [Fact]
+    public void GetFields_ReturnsFiltered()
+    {
+        var fields = typeof(Sample).GetFields().Select(f => f.Name).ToList();
+        Assert.Contains("Field", fields);
+        Assert.Contains("AnnotatedField", fields);
+
+        var annotated = typeof(Sample).GetFields<DescriptionAttribute>().ToList();
+        Assert.Single(annotated);
+        Assert.Equal("AnnotatedField", annotated[0].Name);
+    }
+
+    [Fact]
+    public void GetAttribute_ReturnsAttribute()
+    {
+        var propAttr = typeof(Sample).GetProperty("Annotated")!.GetAttribute<DescriptionAttribute>();
+        Assert.Equal("sample attr", propAttr.Description);
+
+        var fieldAttr = typeof(Sample).GetField("AnnotatedField")!.GetAttribute<DescriptionAttribute>();
+        Assert.Equal("field attr", fieldAttr.Description);
     }
 }


### PR DESCRIPTION
## Summary
- extend `RefletionExtensions` with helpers for listing properties/fields
- add attribute accessors for properties and fields
- test new helpers