### PR TITLE
Add documentation summary for ObjectSerializer

### DIFF
--- a/Core/NE.Standard/Serialization/ObjectSerializer.Deserialize.cs
+++ b/Core/NE.Standard/Serialization/ObjectSerializer.Deserialize.cs
@@ -7,6 +7,9 @@ using System.Linq;
 
 namespace NE.Standard.Serialization
 {
+    /// <summary>
+    /// See <see cref="ObjectSerializer"/> for type information.
+    /// </summary>
     public partial class ObjectSerializer
     {
         public object? Deserialize(string data, bool useBase64 = true)

--- a/Core/NE.Standard/Serialization/ObjectSerializer.Serialize.cs
+++ b/Core/NE.Standard/Serialization/ObjectSerializer.Serialize.cs
@@ -6,6 +6,9 @@ using System.Text;
 
 namespace NE.Standard.Serialization
 {
+    /// <summary>
+    /// See <see cref="ObjectSerializer"/> for type information.
+    /// </summary>
     public partial class ObjectSerializer
     {
         private string SerializeInternal(object obj, bool useBase64 = true, bool ignoreReference = false)

--- a/Core/NE.Standard/Serialization/ObjectSerializer.cs
+++ b/Core/NE.Standard/Serialization/ObjectSerializer.cs
@@ -12,6 +12,11 @@ namespace NE.Standard.Serialization
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class IgnoreAttribute : Attribute { }
 
+    /// <summary>
+    /// Provides methods for serializing and deserializing object graphs.
+    /// The serializer supports collections, dictionaries and preserves
+    /// references between objects when reading or writing.
+    /// </summary>
     public partial class ObjectSerializer : IDisposable
     {
         private const char FIRST_ST = '~';


### PR DESCRIPTION
## Summary
- document the `ObjectSerializer` class
- reference the summary in its partial definitions