### PR TITLE
Optimize ColorPath hex parsing

### DIFF
--- a/Core/NE.Standard.Design/Types/ColorPath.cs
+++ b/Core/NE.Standard.Design/Types/ColorPath.cs
@@ -60,26 +60,29 @@ namespace NE.Standard.Design.Types
         /// <exception cref="InvalidCastException"></exception>
         public static Color GetColor(string hex, FactorType factorType = FactorType.Color, int factor = 0)
         {
-            hex = hex.TrimStart('#');
+            if (hex is null)
+                throw new ArgumentNullException(nameof(hex));
 
-            if (hex.Length == 6)
-                return GetColor(
-                    255,
-                    byte.Parse(hex.Substring(0, 2), NumberStyles.HexNumber),
-                    byte.Parse(hex.Substring(2, 2), NumberStyles.HexNumber),
-                    byte.Parse(hex.Substring(4, 2), NumberStyles.HexNumber),
-                    factorType,
-                    factor
-                );
-            else if (hex.Length == 8)
-                return GetColor(
-                    byte.Parse(hex.Substring(0, 2), NumberStyles.HexNumber),
-                    byte.Parse(hex.Substring(2, 2), NumberStyles.HexNumber),
-                    byte.Parse(hex.Substring(4, 2), NumberStyles.HexNumber),
-                    byte.Parse(hex.Substring(6, 2), NumberStyles.HexNumber),
-                    factorType,
-                    factor
-                );
+            ReadOnlySpan<char> span = hex.AsSpan();
+            if (span.Length > 0 && span[0] == '#')
+                span = span[1..];
+
+            if (span.Length == 6)
+            {
+                byte r = byte.Parse(span.Slice(0, 2), NumberStyles.HexNumber);
+                byte g = byte.Parse(span.Slice(2, 2), NumberStyles.HexNumber);
+                byte b = byte.Parse(span.Slice(4, 2), NumberStyles.HexNumber);
+                return GetColor(255, r, g, b, factorType, factor);
+            }
+
+            if (span.Length == 8)
+            {
+                byte a = byte.Parse(span.Slice(0, 2), NumberStyles.HexNumber);
+                byte r = byte.Parse(span.Slice(2, 2), NumberStyles.HexNumber);
+                byte g = byte.Parse(span.Slice(4, 2), NumberStyles.HexNumber);
+                byte b = byte.Parse(span.Slice(6, 2), NumberStyles.HexNumber);
+                return GetColor(a, r, g, b, factorType, factor);
+            }
 
             throw new InvalidCastException($"{hex} is not a valid HEX format!");
         }

--- a/Tests/NE.Tests.Standard/ColorPathTests.cs
+++ b/Tests/NE.Tests.Standard/ColorPathTests.cs
@@ -1,0 +1,35 @@
+using NE.Standard.Design.Types;
+using System.Drawing;
+
+namespace NE.Tests.Standard;
+
+public class ColorPathTests
+{
+    [Fact]
+    public void GetColor_ParsesSixDigitHex()
+    {
+        var color = ColorPath.GetColor("FF0000");
+        Assert.Equal(Color.FromArgb(255, 255, 0, 0), color);
+    }
+
+    [Fact]
+    public void GetColor_ParsesEightDigitHex()
+    {
+        var color = ColorPath.GetColor("80FF0000");
+        Assert.Equal(Color.FromArgb(128, 255, 0, 0), color);
+    }
+
+    [Fact]
+    public void GetColor_ShadeAppliesFactor()
+    {
+        var color = ColorPath.GetColor("FFFFFF", FactorType.Shade, 5);
+        Assert.Equal(Color.FromArgb(255, 128, 128, 128), color);
+    }
+
+    [Fact]
+    public void GetColor_TintAppliesFactor()
+    {
+        var color = ColorPath.GetColor("000000", FactorType.Tint, 5);
+        Assert.Equal(Color.FromArgb(255, 128, 128, 128), color);
+    }
+}

--- a/Tests/NE.Tests.Standard/NE.Tests.Standard.csproj
+++ b/Tests/NE.Tests.Standard/NE.Tests.Standard.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../../Core/NE.Standard/NE.Standard.csproj" />
+    <ProjectReference Include="../../Core/NE.Standard.Design/NE.Standard.Design.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- speed up `ColorPath.GetColor` by using spans instead of substring
- add unit tests for `ColorPath`
- make tests reference the design project